### PR TITLE
iio_until:fix left shift overflow bug

### DIFF
--- a/src/iio_utils.c
+++ b/src/iio_utils.c
@@ -169,7 +169,7 @@ static inline int iio_utils_get_type(unsigned *is_signed, unsigned *bytes,
 			if (*bits_used == 64)
 				*mask = ~0;
 			else
-				*mask = (1 << *bits_used) - 1;
+				*mask = (1ULL << *bits_used) - 1;
 
 			if (signchar == 's')
 				*is_signed = 1;


### PR DESCRIPTION
if *bit_used is 32,result *mask will be 0.left shift overflow,it is not correct。